### PR TITLE
feat: Add the cmdserver package to handle Diatheke command webhooks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,12 @@ fmt:
 lint-check: $(LINTER)
 	cd cubic && $(LINTER) run --deadline=2m
 	cd diatheke && $(LINTER) run --deadline=2m
+	cd cmdserver && $(LINTER) run --deadline=2m
 
 # Run tests
 .PHONY: test
 test: 
-	@echo Because this is just sample code, there are no tests, but Jenkins requires there to be a test target
+	cd cmdserver && go test -cover -race ./...
 
 # Build
 .PHONY: build-cubic-example

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ The [diatheke](./diatheke) folder contains two example clients that interact wit
 * [cli_client](./diatheke/cmd/cli_client) is a text only interface where the application processes text from the user, then gives a reply as text.
 
 See [here](./diatheke/README.md) for more details.
+
+## Diatheke Command Server
+The [cmdserver](./cmdserver) folder contains a go package that may be imported by other
+projects to create an http server that can handle command fulfillment if the Diatheke
+model supports sending commands to a webhook. See [here](./cmdserver/README.md) for
+more details.
+

--- a/cmdserver/README.md
+++ b/cmdserver/README.md
@@ -1,0 +1,58 @@
+# Diatheke Command Server
+
+This package provides a simple http server that may be used for
+Diatheke [command fulfillment](https://docs.cobaltspeech.com/vui/diatheke/reference/command/#fulfillment-webhook).
+Such a server should be deployed with Diatheke, Cubic, Luna, etc.
+so that the Diatheke server can access the command server.
+
+## Security
+Note that this server only supports http at the present. It does
+not allow secure connections (https), so any data sent to this
+server will not be encrypted. As such, it is not recommended to
+use this server for production.
+
+## Usage
+Import the package using the `go` tool:
+
+```bash
+go get -u github.com/cobaltspeech/examples-go/cmdserver
+```
+
+To use the command server, create a new server, register
+command handlers and run.
+
+```go
+type SomeHandler struct {
+	// Contains some data fields
+}
+
+func (h *SomeHandler) fooCmd(input cmdserver.Params) (cmdserver.Params, error) {
+	// Do something interesting with the command input.
+	return nil, nil
+}
+
+func (h *SomeHandler) barCmd(input cmdserver.Params) (cmdserver.Params, error) {
+	// Do something interseting with the command input.
+
+	// Create the output parameters
+	outParams := make(cmdserver.Params)
+	outParams["expectedKey"] = "expectedVal"
+
+	return outParams, nil
+}
+
+func main() {
+	// Create the server (with an optional logger if desired)
+	svr := cmdserver.NewServer(nil)
+
+	// Set handlers for command IDs
+	handler := SomeHandler{}
+	svr.SetHandler("foo", handler.fooCmd)
+	svr.SetHandler("bar", handler.barCmd)
+
+	// Run the server
+	if err := svr.Run(":24601"); err != nil {
+		os.Exit(1)
+	}
+}
+```

--- a/cmdserver/README.md
+++ b/cmdserver/README.md
@@ -32,7 +32,7 @@ func (h *SomeHandler) fooCmd(input cmdserver.Params) (cmdserver.Params, error) {
 }
 
 func (h *SomeHandler) barCmd(input cmdserver.Params) (cmdserver.Params, error) {
-	// Do something interseting with the command input.
+	// Do something interesting with the command input.
 
 	// Create the output parameters
 	outParams := make(cmdserver.Params)

--- a/cmdserver/go.mod
+++ b/cmdserver/go.mod
@@ -1,0 +1,8 @@
+module github.com/cobaltspeech/examples-go/cmdserver
+
+go 1.16
+
+require (
+	github.com/cobaltspeech/log v0.1.11
+	github.com/google/go-cmp v0.5.1
+)

--- a/cmdserver/go.sum
+++ b/cmdserver/go.sum
@@ -1,0 +1,6 @@
+github.com/cobaltspeech/log v0.1.11 h1:d+/NFqpavl0h1sLhXKde29bTeyjE5RnBz+Xn5Q7kIjc=
+github.com/cobaltspeech/log v0.1.11/go.mod h1:ZKH2mBkseADkwBBWKCeWcxgO4HZANwvSDujBT2pEcrI=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/cmdserver/params.go
+++ b/cmdserver/params.go
@@ -1,0 +1,120 @@
+// Copyright (2021) Cobalt Speech and Language Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdserver
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Params is an alias for a map[string]string that
+// includes some convenience functions for converting
+// to other types. To create a new Params object, use
+// the go standard make function (e.g., `make(Params)`).
+type Params map[string]string
+
+// AsString returns the parameter value for the given key
+// as a string. Returns an error if the key was not found.
+// Note that the underlying map may be used directly to
+// get the parameter and check it's existence without the
+// error (e.g., `val, ok := p[key]`).
+func (p Params) AsString(key string) (string, error) {
+	val, found := p[key]
+	if !found {
+		return val, fmt.Errorf("missing key %q", key)
+	}
+
+	return val, nil
+}
+
+// SetString sets the parameter value for the given key.
+// This is no different than setting it directly on the
+// object (e.g., `p[key] = val`).
+func (p Params) SetString(key, val string) {
+	p[key] = val
+}
+
+// AsInt returns the parameter value for the given key
+// as an int. Returns an error if the key was not found
+// or there was a problem during conversion.
+func (p Params) AsInt(key string) (int, error) {
+	if val, err := p.AsString(key); err != nil {
+		return 0, err
+	} else {
+		return strconv.Atoi(val)
+	}
+}
+
+// SetInt converts the given int to a string and stores
+// it in the parameter map.
+func (p Params) SetInt(key string, val int) {
+	p[key] = strconv.Itoa(val)
+}
+
+// AsFloat32 returns the parameter value for the given key
+// as a float32. Returns an error if the key was not found
+// or there was problem during conversion.
+func (p Params) AsFloat32(key string) (float32, error) {
+	if val, err := p.AsString(key); err != nil {
+		return 0.0, err
+	} else {
+		f, err := strconv.ParseFloat(val, 32)
+		return float32(f), err
+	}
+}
+
+// SetFloat32 converts the given float32 to a string and stores
+// it in the parameter map. This uses the 'g' formatting style
+// for the conversion, with a precision of 4. For different
+// formatting, it is recommended to use strconv.FormatFloat().
+func (p Params) SetFloat32(key string, val float32) {
+	p[key] = strconv.FormatFloat(float64(val), 'g', 4, 32)
+}
+
+// AsFloat64 returns the parameter value for the given key
+// as a float64. Returns an error if the key was not found
+// or there was a problem during conversion.
+func (p Params) AsFloat64(key string) (float64, error) {
+	if val, err := p.AsString(key); err != nil {
+		return 0.0, err
+	} else {
+		return strconv.ParseFloat(val, 64)
+	}
+}
+
+// SetFloat64 converts the given float64 to a string and stores
+// it in the parameter map. This uses the 'g' formatting style
+// for the conversion, with a precision of 4. For different
+// formatting, it is recommended to use strconv.FormatFloat().
+func (p Params) SetFloat64(key string, val float64) {
+	p[key] = strconv.FormatFloat(val, 'g', 4, 64)
+}
+
+// AsBool returns the parameter value for the given key
+// as a bool. Returns an error if the key was not found
+// or there was a problem during conversion.
+func (p Params) AsBool(key string) (bool, error) {
+	if val, err := p.AsString(key); err != nil {
+		return false, err
+	} else {
+		return strconv.ParseBool(val)
+	}
+}
+
+// SetBool converts the given bool to a string and stores it
+// in the parameter map.
+func (p Params) SetBool(key string, val bool) {
+	p[key] = strconv.FormatBool(val)
+}

--- a/cmdserver/params.go
+++ b/cmdserver/params.go
@@ -23,6 +23,9 @@ import (
 // includes some convenience functions for converting
 // to other types. To create a new Params object, use
 // the go standard make function (e.g., `make(Params)`).
+// Note that the convenience functions are not safe
+// to use concurrently (just as it is not safe to
+// access a regular map in Go concurrently).
 type Params map[string]string
 
 // AsString returns the parameter value for the given key

--- a/cmdserver/params_test.go
+++ b/cmdserver/params_test.go
@@ -1,0 +1,125 @@
+// Copyright (2021) Cobalt Speech and Language Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdserver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	foo = "foo"
+	bar = "bar"
+	baz = "baz"
+)
+
+func TestParamsString(t *testing.T) {
+	expected := map[string]string{
+		foo: "this is fooey",
+		bar: "a llama walks into a",
+		baz: "what does this even mean",
+	}
+
+	p := make(Params)
+	p.SetString(foo, expected[foo])
+	p.SetString(bar, expected[bar])
+	p.SetString(baz, expected[baz])
+
+	if diff := cmp.Diff(map[string]string(p), expected); diff != "" {
+		t.Errorf(diff)
+	}
+
+	for key, exp := range expected {
+		if val, err := p.AsString(key); err != nil {
+			t.Error(err)
+		} else if val != exp {
+			t.Errorf("incorrect val for %q - expected: %q, actual: %q",
+				key, exp, val)
+		}
+	}
+}
+
+func TestParamsInt(t *testing.T) {
+	expected := "17"
+	expectedInt := 17
+
+	p := make(Params)
+	p.SetInt(foo, expectedInt)
+
+	if p[foo] != expected {
+		t.Errorf("incorrect value - expected: %v, actual: %v", expected, p[foo])
+	}
+
+	if val, err := p.AsInt(foo); err != nil {
+		t.Error(err)
+	} else if val != expectedInt {
+		t.Errorf("incorrect int - expected: %v, actual: %v", expectedInt, val)
+	}
+}
+
+func TestParamsFloat32(t *testing.T) {
+	expected := "1.372"
+	expectedFloat := float32(1.372)
+
+	p := make(Params)
+	p.SetFloat32(foo, expectedFloat)
+
+	if p[foo] != expected {
+		t.Errorf("incorrect value - expected: %v, actual: %v", expected, p[foo])
+	}
+
+	if val, err := p.AsFloat32(foo); err != nil {
+		t.Error(err)
+	} else if val != expectedFloat {
+		t.Errorf("incorrect float32 - expected: %v, actual: %v", expectedFloat, val)
+	}
+}
+
+func TestParamsFloat64(t *testing.T) {
+	expected := "0.3215"
+	expectedFloat := float64(0.3215)
+
+	p := make(Params)
+	p.SetFloat64(foo, expectedFloat)
+
+	if p[foo] != expected {
+		t.Errorf("incorrect value - expected: %v, actual: %v", expected, p[foo])
+	}
+
+	if val, err := p.AsFloat64(foo); err != nil {
+		t.Error(err)
+	} else if val != expectedFloat {
+		t.Errorf("incorrect float64 - expected: %v, actual: %v", expectedFloat, val)
+	}
+}
+
+func TestParamsBool(t *testing.T) {
+	expected := "true"
+	expectedBool := true
+
+	p := make(Params)
+	p.SetBool(foo, expectedBool)
+
+	if p[foo] != expected {
+		t.Errorf("incorrect value - expected: %v, actual: %v", expected, p[foo])
+	}
+
+	if val, err := p.AsBool(foo); err != nil {
+		t.Error(err)
+	} else if val != expectedBool {
+		t.Errorf("incorrect bool - expected: %v, actual: %v", expectedBool, val)
+	}
+}

--- a/cmdserver/server.go
+++ b/cmdserver/server.go
@@ -1,0 +1,176 @@
+// Copyright (2021) Cobalt Speech and Language Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/cobaltspeech/log"
+)
+
+// Handler is a function that takes a map of input parameters
+// and returns a (possibly empty or nil) map of output parameters,
+// as expected by a Diatheke command.
+type Handler func(Params) (Params, error)
+
+// Server represents an http server that handles Diatheke
+// commands. With this server, all commands go to the same
+// URL, so the Diatheke model should be set accordingly.
+// Once received, commands are sent to Handlers added with
+// the SetHandler function.
+type Server struct {
+	logger       log.Logger
+	handlerFuncs map[string]Handler
+}
+
+// NewServer returns a new command server.
+func NewServer(logger log.Logger) Server {
+	if logger == nil {
+		logger = log.NewDiscardLogger()
+	}
+
+	return Server{
+		logger:       logger,
+		handlerFuncs: make(map[string]Handler),
+	}
+}
+
+// SetHandler registers the provided Handler to be called for
+// the specified command ID.
+func (svr *Server) SetHandler(cmdID string, h Handler) {
+	svr.handlerFuncs[cmdID] = h
+}
+
+// Run starts the http server and listens at the given address
+// (e.g., ":8072", "localhost:1515", "127.0.0.1:3535") until
+// either an error occurs or the interrupt signal is received.
+func (svr *Server) Run(address string) error {
+	// Create the tcp connection
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		return err
+	}
+
+	// Get the address in case ":0" was used as the port number,
+	// in which case a port was automatically selected.
+	address = lis.Addr().(*net.TCPAddr).String()
+
+	// Set up the http server.
+	hsvr := &http.Server{
+		Addr:    address,
+		Handler: svr,
+	}
+
+	// Use an error channel to collect errors from the go
+	// routine that listens on the port.
+	errCh := make(chan error, 1)
+
+	// Listen in a different go routine so that we can still
+	// respond to the keyboard interrupt.
+	go func() {
+		errCh <- hsvr.Serve(lis)
+	}()
+	svr.logger.Info(
+		"msg", "server started",
+		"httpAddr", address,
+	)
+
+	// Catch the interrupt signal to gracefully shutdown the server
+	const maxInterrupts = 10
+	interrupt := make(chan os.Signal, maxInterrupts)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+
+	// Wait for an error or an interrupt
+	select {
+	case err = <-errCh:
+		return err
+
+	case <-interrupt:
+		svr.logger.Info("msg", "shutting down http server...")
+
+		// Gracefully shut down the server
+		const timeout = 10 * time.Second
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		return hsvr.Shutdown(ctx)
+	}
+}
+
+// ServeHTTP implements the http.Handler interface. It decodes
+// the command, forwards the data to the correct command Handler,
+// then encodes the result to send back to Diatheke.
+func (svr *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Read the JSON request
+	decoder := json.NewDecoder(r.Body)
+	var cmd cmdRequest
+	if err := decoder.Decode(&cmd); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Find the appropriate handler
+	handler, found := svr.handlerFuncs[cmd.ID]
+	if !found || handler == nil {
+		http.Error(
+			w,
+			fmt.Sprintf("could not find handler for command %q", cmd.ID),
+			http.StatusInternalServerError,
+		)
+		svr.logger.Error(
+			"msg", "could not find command handler",
+			"cmd", cmd.ID,
+		)
+		return
+	}
+
+	// Run the command
+	outParams, err := handler(cmd.InputParameters)
+	result := cmdResponse{
+		ID:            cmd.ID,
+		OutParameters: outParams,
+	}
+	if err != nil {
+		result.Error = err.Error()
+	}
+
+	// Send the command result
+	w.Header().Set("Content-Type", "application/json")
+	encoder := json.NewEncoder(w)
+	if err = encoder.Encode(&result); err != nil {
+		svr.logger.Error(
+			"msg", "failed to write command response",
+			"error", err,
+		)
+	}
+}
+
+type cmdRequest struct {
+	ID              string            `json:"id"`
+	InputParameters map[string]string `json:"inputParameters"`
+}
+
+type cmdResponse struct {
+	ID            string            `json:"id"`
+	OutParameters map[string]string `json:"outParameters,omitempty"`
+	Error         string            `json:"error,omitempty"`
+}

--- a/cmdserver/server_test.go
+++ b/cmdserver/server_test.go
@@ -1,0 +1,157 @@
+// Copyright (2021) Cobalt Speech and Language Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestServerEndpoint(t *testing.T) {
+	// Create the server
+	svr := NewServer(nil)
+
+	// Add handlers (and expected test data)
+	cmd1ExpectedIn := cmdRequest{
+		ID: "cmd1",
+		InputParameters: map[string]string{
+			"a": "some data",
+			"b": "other data",
+		},
+	}
+
+	cmd1ExpectedOut := cmdResponse{ID: "cmd1"}
+
+	svr.SetHandler("cmd1", func(input Params) (Params, error) {
+		diff := cmp.Diff(
+			cmd1ExpectedIn.InputParameters,
+			map[string]string(input),
+		)
+		if diff != "" {
+			t.Error(diff)
+		}
+
+		return nil, nil
+	})
+
+	cmd5ExpectedIn := cmdRequest{ID: "cmd5"}
+	cmd5ExpectedOut := cmdResponse{
+		ID: "cmd5",
+		OutParameters: map[string]string{
+			"c": "crazy",
+			"d": "silly",
+		},
+	}
+	svr.SetHandler("cmd5", func(input Params) (Params, error) {
+		if len(input) != 0 {
+			t.Errorf("got unexpected input params: %+v", input)
+		}
+
+		return cmd5ExpectedOut.OutParameters, nil
+	})
+
+	// Create the test server
+	tsvr := httptest.NewServer(&svr)
+	defer tsvr.Close()
+
+	client := tsvr.Client()
+	send := func(cmd cmdRequest) (cmdResponse, error) {
+		var body bytes.Buffer
+		encoder := json.NewEncoder(&body)
+		if sErr := encoder.Encode(&cmd); sErr != nil {
+			return cmdResponse{}, sErr
+		}
+
+		resp, sErr := client.Post(tsvr.URL, "application/json", &body)
+		if sErr != nil {
+			return cmdResponse{}, sErr
+		}
+		defer resp.Body.Close()
+
+		decoder := json.NewDecoder(resp.Body)
+		var result cmdResponse
+		sErr = decoder.Decode(&result)
+		return result, sErr
+	}
+
+	if cmd1Out, err := send(cmd1ExpectedIn); err != nil {
+		t.Error(err)
+	} else if diff := cmp.Diff(cmd1ExpectedOut, cmd1Out); diff != "" {
+		t.Error(diff)
+	}
+
+	if cmd5Out, err := send(cmd5ExpectedIn); err != nil {
+		t.Error(err)
+	} else if diff := cmp.Diff(cmd5ExpectedOut, cmd5Out); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestUnknownCmd(t *testing.T) {
+	// Create the server
+	svr := NewServer(nil)
+	svr.SetHandler("junk", func(Params) (Params, error) {
+		t.Error("called handler when it shouldn't")
+		return nil, nil
+	})
+
+	// Create the test server
+	tsvr := httptest.NewServer(&svr)
+	defer tsvr.Close()
+
+	client := tsvr.Client()
+	var body bytes.Buffer
+	if _, err := body.WriteString(`{"id": "not_junk"}`); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Post(tsvr.URL, "application/json", &body)
+	if err != nil {
+		t.Error(err)
+	} else if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("did not get status InternalServerError in response")
+	}
+}
+
+func TestBadRequest(t *testing.T) {
+	// Create the server
+	svr := NewServer(nil)
+	svr.SetHandler("junk", func(Params) (Params, error) {
+		t.Error("called handler when it shouldn't")
+		return nil, nil
+	})
+
+	// Create the test server
+	tsvr := httptest.NewServer(&svr)
+	defer tsvr.Close()
+
+	client := tsvr.Client()
+	var body bytes.Buffer
+	if _, err := body.WriteString(`{"bad_request":"hahaha"`); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Post(tsvr.URL, "application/json", &body)
+	if err != nil {
+		t.Error(err)
+	} else if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("did not get status BadRequest in response")
+	}
+}


### PR DESCRIPTION
This example package contains classes to allow users to experiment
with using webhooks for command fulfillment, provided the Diatheke
model is set up to handle commands this way. See the READMEs for
details on how to use the package.