### PR TITLE
refactor (cmdserver): Add new command data and change handler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cubic/transcribe
 **/.DS_Store
 cubic/DemoCallCenterAudioTranscripts/*
 cubic/friendly/*
+.vscode

--- a/cmdserver/README.md
+++ b/cmdserver/README.md
@@ -26,19 +26,20 @@ type SomeHandler struct {
 	// Contains some data fields
 }
 
-func (h *SomeHandler) fooCmd(input cmdserver.Params) (cmdserver.Params, error) {
+func (h *SomeHandler) fooCmd(
+	in cmdserver.Input, out *cmdserver.Output) error {
 	// Do something interesting with the command input.
-	return nil, nil
+	return nil
 }
 
-func (h *SomeHandler) barCmd(input cmdserver.Params) (cmdserver.Params, error) {
+func (h *SomeHandler) barCmd(
+	in cmdserver.Input, out *cmdserver.Output) error {
 	// Do something interesting with the command input.
 
-	// Create the output parameters
-	outParams := make(cmdserver.Params)
-	outParams["expectedKey"] = "expectedVal"
+	// Set output parameters
+	out.Parameters["expectedKey"] = "expectedVal"
 
-	return outParams, nil
+	return nil
 }
 
 func main() {
@@ -47,8 +48,13 @@ func main() {
 
 	// Set handlers for command IDs
 	handler := SomeHandler{}
-	svr.SetHandler("foo", handler.fooCmd)
-	svr.SetHandler("bar", handler.barCmd)
+	svr.SetCommand("foo", handler.fooCmd)
+	svr.SetCommand("bar", handler.barCmd)
+
+	// It is also possible to set handlers based on model ID
+	// or model ID + command ID.
+	// svr.SetModel("modelID", handlerFunc)
+	// svr.SetModelCommand("modelID", "cmdID", handlerFunc)
 
 	// Run the server
 	if err := svr.Run(":24601"); err != nil {

--- a/cmdserver/datatypes.go
+++ b/cmdserver/datatypes.go
@@ -1,0 +1,62 @@
+// Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdserver
+
+// Input contains the command input data as received from
+// Diatheke.
+type Input struct {
+	// The Diatheke model ID where the command is defined.
+	ModelID string `json:"modelID"`
+
+	// The ID of the command to execute.
+	CommandID string `json:"id"`
+
+	// The unique ID of the session trying to execute the command.
+	SessionID string `json:"sessionID"`
+
+	// Defined parameters (possibly empty).
+	Parameters Params `json:"inputParameters"`
+
+	// Application specific, user-defined data. Implementers
+	// may use this field to store arbitrary data for a session.
+	// Implementers are responsible for passing this data to the
+	// command Output, and are free to modify it however they
+	// want (or clear it entirely).
+	Metadata string `json:"metadata"`
+}
+
+// Output contains the command data to send back to Diatheke.
+type Output struct {
+	// The ID of the command that was executed
+	CommandID string `json:"id"`
+
+	// Parameters that Diatheke expects to be returned (possibly
+	// empty).
+	Parameters Params `json:"outParameters,omitempty"`
+
+	// Application specific, user-defined data to associate
+	// with the session that executed this command.
+	Metadata string `json:"metadata,omitempty"`
+
+	// An error message to indicate to Diatheke that something
+	// went wrong during command execution. Most implementers
+	// won't need to set this field directly as it set by the
+	// server when an error is returned from the handler.
+	Error string `json:"error,omitempty"`
+}
+
+// Handler is a function that takes command input and sets
+// the command output that is expected by a Diatheke command.
+type Handler func(in Input, out *Output) error

--- a/cmdserver/params.go
+++ b/cmdserver/params.go
@@ -1,4 +1,4 @@
-// Copyright (2021) Cobalt Speech and Language Inc.
+// Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmdserver/params_test.go
+++ b/cmdserver/params_test.go
@@ -1,4 +1,4 @@
-// Copyright (2021) Cobalt Speech and Language Inc.
+// Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmdserver/server.go
+++ b/cmdserver/server.go
@@ -178,6 +178,7 @@ func (svr *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	output := Output{
 		CommandID:  input.CommandID,
 		Parameters: make(Params),
+		Metadata:   input.Metadata,
 	}
 	err := handler(input, &output)
 	if err != nil {

--- a/cmdserver/server_test.go
+++ b/cmdserver/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (2021) Cobalt Speech and Language Inc.
+// Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package cmdserver
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,80 +25,61 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestServerEndpoint(t *testing.T) {
+func TestSetCommand(t *testing.T) {
 	// Create the server
 	svr := NewServer(nil)
 
 	// Add handlers (and expected test data)
-	cmd1ExpectedIn := cmdRequest{
-		ID: "cmd1",
-		InputParameters: map[string]string{
+	cmd1ExpectedIn := Input{
+		SessionID: "random31234",
+		ModelID:   "1",
+		CommandID: "cmd1",
+		Parameters: Params{
 			"a": "some data",
 			"b": "other data",
 		},
 	}
 
-	cmd1ExpectedOut := cmdResponse{ID: "cmd1"}
+	cmd1ExpectedOut := Output{CommandID: "cmd1"}
 
-	svr.SetHandler("cmd1", func(input Params) (Params, error) {
-		diff := cmp.Diff(
-			cmd1ExpectedIn.InputParameters,
-			map[string]string(input),
-		)
+	svr.SetCommand("cmd1", func(in Input, out *Output) error {
+		diff := cmp.Diff(cmd1ExpectedIn.Parameters, in.Parameters)
 		if diff != "" {
 			t.Error(diff)
 		}
 
-		return nil, nil
+		return nil
 	})
 
-	cmd5ExpectedIn := cmdRequest{ID: "cmd5"}
-	cmd5ExpectedOut := cmdResponse{
-		ID: "cmd5",
-		OutParameters: map[string]string{
+	cmd5ExpectedIn := Input{CommandID: "cmd5"}
+	cmd5ExpectedOut := Output{
+		CommandID: "cmd5",
+		Parameters: Params{
 			"c": "crazy",
 			"d": "silly",
 		},
 	}
-	svr.SetHandler("cmd5", func(input Params) (Params, error) {
-		if len(input) != 0 {
-			t.Errorf("got unexpected input params: %+v", input)
+	svr.SetCommand("cmd5", func(in Input, out *Output) error {
+		if len(in.Parameters) != 0 {
+			t.Errorf("got unexpected input params: %+v", in.Parameters)
 		}
 
-		return cmd5ExpectedOut.OutParameters, nil
+		*out = cmd5ExpectedOut
+		return nil
 	})
 
-	// Create the test server
+	// Create the test server and client
 	tsvr := httptest.NewServer(&svr)
 	defer tsvr.Close()
+	client := newTestClient(tsvr)
 
-	client := tsvr.Client()
-	send := func(cmd cmdRequest) (cmdResponse, error) {
-		var body bytes.Buffer
-		encoder := json.NewEncoder(&body)
-		if sErr := encoder.Encode(&cmd); sErr != nil {
-			return cmdResponse{}, sErr
-		}
-
-		resp, sErr := client.Post(tsvr.URL, "application/json", &body)
-		if sErr != nil {
-			return cmdResponse{}, sErr
-		}
-		defer resp.Body.Close()
-
-		decoder := json.NewDecoder(resp.Body)
-		var result cmdResponse
-		sErr = decoder.Decode(&result)
-		return result, sErr
-	}
-
-	if cmd1Out, err := send(cmd1ExpectedIn); err != nil {
+	if cmd1Out, err := client.send(cmd1ExpectedIn); err != nil {
 		t.Error(err)
 	} else if diff := cmp.Diff(cmd1ExpectedOut, cmd1Out); diff != "" {
 		t.Error(diff)
 	}
 
-	if cmd5Out, err := send(cmd5ExpectedIn); err != nil {
+	if cmd5Out, err := client.send(cmd5ExpectedIn); err != nil {
 		t.Error(err)
 	} else if diff := cmp.Diff(cmd5ExpectedOut, cmd5Out); diff != "" {
 		t.Error(diff)
@@ -107,9 +89,9 @@ func TestServerEndpoint(t *testing.T) {
 func TestUnknownCmd(t *testing.T) {
 	// Create the server
 	svr := NewServer(nil)
-	svr.SetHandler("junk", func(Params) (Params, error) {
+	svr.SetCommand("junk", func(Input, *Output) error {
 		t.Error("called handler when it shouldn't")
-		return nil, nil
+		return nil
 	})
 
 	// Create the test server
@@ -133,9 +115,9 @@ func TestUnknownCmd(t *testing.T) {
 func TestBadRequest(t *testing.T) {
 	// Create the server
 	svr := NewServer(nil)
-	svr.SetHandler("junk", func(Params) (Params, error) {
+	svr.SetCommand("junk", func(Input, *Output) error {
 		t.Error("called handler when it shouldn't")
-		return nil, nil
+		return nil
 	})
 
 	// Create the test server
@@ -154,4 +136,123 @@ func TestBadRequest(t *testing.T) {
 	} else if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("did not get status BadRequest in response")
 	}
+}
+
+func TestHandlerRegistry(t *testing.T) {
+	hr := newRegistry()
+	hr.setModelCmd("m1", "c1", func(in Input, out *Output) error {
+		if in.ModelID != "m1" || in.CommandID != "c1" || in.Parameters["target"] != "m1c1" {
+			return fmt.Errorf("wrong input sent to m1c1: %v", in)
+		}
+
+		return nil
+	})
+
+	hr.setCmd("c1", func(in Input, out *Output) error {
+		if in.CommandID != "c1" || in.Parameters["target"] != "c1" {
+			return fmt.Errorf("wrong input sent to c1: %v", in)
+		}
+
+		return nil
+	})
+
+	hr.setCmd("c2", func(in Input, out *Output) error {
+		if in.CommandID != "c2" || in.Parameters["target"] != "c2" {
+			return fmt.Errorf("wrong input sent to c2: %v", in)
+		}
+
+		return nil
+	})
+
+	hr.setModel("m1", func(in Input, out *Output) error {
+		if in.ModelID != "m1" || in.Parameters["target"] != "m1" {
+			return fmt.Errorf("wrong input sent to m1: %v", in)
+		}
+
+		return nil
+	})
+
+	hr.setModel("m2", func(in Input, out *Output) error {
+		if in.ModelID != "m2" || in.Parameters["target"] != "m2" {
+			return fmt.Errorf("wrong input sent to m2: %v", in)
+		}
+
+		return nil
+	})
+
+	// Now that the registry is set up, run tests
+	testList := []struct {
+		modelID string
+		cmdID   string
+		target  string
+		found   bool
+	}{
+		{"m1", "c1", "m1c1", true},
+		{"x", "c1", "c1", true},
+		{"x", "c2", "c2", true},
+		{"m1", "y", "m1", true},
+		{"m2", "y", "m2", true},
+		{"x", "x", "", false},
+		{"m1", "c2", "c2", true},
+		{"m2", "c1", "c1", true},
+		{"m2", "c2", "c2", true},
+	}
+
+	for i := range testList {
+		test := testList[i]
+		name := test.modelID + "-" + test.cmdID
+		t.Run(name, func(t *testing.T) {
+			in := Input{
+				ModelID:    test.modelID,
+				CommandID:  test.cmdID,
+				Parameters: make(Params),
+			}
+			in.Parameters.SetString("target", test.target)
+
+			handler, found := hr.findHandler(in)
+			if found != test.found {
+				t.Fatalf("found flag mismatch - expected: %v, actual: %v",
+					test.found, found)
+			}
+
+			if !found {
+				return
+			}
+
+			if err := handler(in, nil); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+type testClient struct {
+	client *http.Client
+	url    string
+}
+
+func newTestClient(svr *httptest.Server) testClient {
+	return testClient{
+		client: svr.Client(),
+		url:    svr.URL,
+	}
+}
+
+func (tc *testClient) send(in Input) (Output, error) {
+	var body bytes.Buffer
+	encoder := json.NewEncoder(&body)
+	if err := encoder.Encode(&in); err != nil {
+		return Output{}, err
+	}
+
+	resp, err := tc.client.Post(tc.url, "application/json", &body)
+	if err != nil {
+		return Output{}, err
+	}
+	defer resp.Body.Close()
+
+	decoder := json.NewDecoder(resp.Body)
+	var result Output
+	err = decoder.Decode(&result)
+	return result, err
 }


### PR DESCRIPTION
Updated command data structs to include new fields that will be
available starting with Diatheke v3. These fields include session
and model IDs and application-defined metadata.

Also updated the handler function signature to pass in the command
output struct so that it is no longer the handler's responsibility
to instantiate it. Instead all the handler needs to do is set
values on the output data. Also changed the signature so that it
passes in all the new data fields instead of only the command
parameters.